### PR TITLE
feat: move_root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -745,6 +745,7 @@ dependencies = [
  "futures",
  "futures-core",
  "futures-util",
+ "libc",
  "libcgroups",
  "libcontainer",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lints.rust]
-unsafe_code = "forbid"
+unsafe_code = "deny"
 
 [lints.clippy]
 enum_glob_use = "deny"
@@ -15,7 +15,7 @@ enum_glob_use = "deny"
 futures = "0.3.30"
 netlink-packet-route = "~0.19.0"
 rtnetlink = "0.14.0"
-nix = { version = "0.29.0", features = ["mount", "user", "reboot", "feature", "net", "aio", "signal", "process"] }
+nix = { version = "0.29.0", features = ["mount", "user", "reboot", "feature", "net", "aio", "signal", "process", "fs"] }
 tokio = { version = "1.38.0", features = ["full", "macros", "rt-multi-thread"] }
 log = "0.4.22"
 simple_logger = "5.0.0"
@@ -44,6 +44,7 @@ chrono = "0.4"
 futures-util = "0.3"
 futures-core = "0.3"
 async-stream = "0.3"
+libc = "0.2"
 
 [build-dependencies]
 tonic-build = "0.12.1"

--- a/src/fsmount.rs
+++ b/src/fsmount.rs
@@ -1,0 +1,48 @@
+use libc::{syscall, SYS_fsconfig, SYS_fsmount, SYS_fsopen};
+use nix::{errno::Errno, Result};
+use std::{
+    ffi::CString,
+    os::fd::{AsRawFd, BorrowedFd, RawFd},
+    ptr::null,
+};
+
+#[allow(unsafe_code)]
+pub fn fsopen(fsname: &str, flags: u32) -> Result<RawFd> {
+    let fsname_cstring = CString::new(fsname).unwrap_or_default();
+    let ret = unsafe { syscall(SYS_fsopen, fsname_cstring.as_ptr(), flags) };
+    Errno::result(ret.try_into().unwrap())
+}
+
+#[allow(unsafe_code)]
+pub fn fsconfig(
+    fd: BorrowedFd,
+    cmd: u32,
+    key: Option<&str>,
+    value: Option<&str>,
+    aux: i32,
+) -> Result<RawFd> {
+    let key_cstring = key.map(|key| CString::new(key).unwrap_or_default());
+    let value_cstring = value.map(|value| CString::new(value).unwrap_or_default());
+
+    let key_ptr = match key_cstring.as_ref() {
+        Some(key) => key.as_ptr(),
+        None => null(),
+    };
+    let value_ptr = match value_cstring.as_ref() {
+        Some(value) => value.as_ptr(),
+        None => null(),
+    };
+
+    let ret = unsafe { syscall(SYS_fsconfig, fd.as_raw_fd(), cmd, key_ptr, value_ptr, aux) };
+
+    Errno::result(ret.try_into().unwrap())
+}
+
+pub const FSCONFIG_SET_STRING: u32 = 1;
+pub const FSCONFIG_CMD_CREATE: u32 = 6;
+
+#[allow(unsafe_code)]
+pub fn fsmount(fd: BorrowedFd, flags: u32, mount_attr: u32) -> Result<RawFd> {
+    let ret = unsafe { syscall(SYS_fsmount, fd.as_raw_fd(), flags, mount_attr) };
+    Errno::result(ret.try_into().unwrap())
+}

--- a/src/move_root.rs
+++ b/src/move_root.rs
@@ -1,0 +1,115 @@
+use nix::{
+    fcntl::{openat, OFlag},
+    mount::{mount, MsFlags},
+    sys::stat::{mknod, stat, Mode, SFlag},
+    unistd::{chroot, fchdir},
+};
+use std::{
+    fs::{copy, create_dir, read_dir, read_link, remove_dir, remove_file, File},
+    io::{self, BufRead, BufReader},
+    os::{
+        fd::{AsFd, AsRawFd, FromRawFd, OwnedFd},
+        unix::fs::{symlink, FileTypeExt},
+    },
+    path::Path,
+};
+
+use crate::fsmount::{fsconfig, fsmount, fsopen, FSCONFIG_CMD_CREATE, FSCONFIG_SET_STRING};
+
+#[allow(unsafe_code)]
+pub fn get_root_fstype() -> Result<String, Box<dyn std::error::Error>> {
+    let proc_fs_raw = fsopen("proc", 0)?;
+    let proc_fs = unsafe { OwnedFd::from_raw_fd(proc_fs_raw) };
+
+    fsconfig(proc_fs.as_fd(), FSCONFIG_CMD_CREATE, None, None, 0)?;
+
+    let proc_dir_raw = fsmount(proc_fs.as_fd(), 0, 0)?;
+    let proc_dir = unsafe { OwnedFd::from_raw_fd(proc_dir_raw) };
+
+    let mounts_raw = openat(
+        Some(proc_dir.as_raw_fd()),
+        "mounts",
+        OFlag::O_RDONLY,
+        Mode::empty(),
+    )?;
+    let mounts = unsafe { File::from_raw_fd(mounts_raw) };
+
+    let reader = BufReader::new(mounts);
+
+    for line in reader.lines() {
+        let line = line?;
+        let fields: Vec<&str> = line.split_whitespace().collect();
+
+        if fields.len() >= 3 && fields[1] == "/" {
+            return Ok(fields[2].to_string());
+        }
+    }
+
+    Err("could not determine root fstype".into())
+}
+
+#[allow(unsafe_code)]
+pub fn move_root() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp_fs_raw = fsopen("tmpfs", 0)?;
+    let tmp_fs = unsafe { OwnedFd::from_raw_fd(tmp_fs_raw) };
+
+    fsconfig(
+        tmp_fs.as_fd(),
+        FSCONFIG_SET_STRING,
+        Some("mode"),
+        Some("0755"),
+        0,
+    )?;
+    fsconfig(tmp_fs.as_fd(), FSCONFIG_CMD_CREATE, None, None, 0)?;
+
+    let tmp_dir_raw = fsmount(tmp_fs.as_fd(), 0, 0)?;
+    let tmp_dir = unsafe { OwnedFd::from_raw_fd(tmp_dir_raw) };
+
+    fchdir(tmp_dir.as_raw_fd())?;
+    move_recursively(Path::new("/"), Path::new("."))?;
+
+    mount(
+        Some("." as &str),
+        "/" as &str,
+        None::<&str>,
+        MsFlags::MS_MOVE,
+        None::<&str>,
+    )?;
+    chroot(".")?;
+
+    Ok(())
+}
+
+fn move_recursively(source: impl AsRef<Path>, destination: impl AsRef<Path>) -> io::Result<()> {
+    for entry in read_dir(source)? {
+        let entry = entry?;
+        let filetype = entry.file_type()?;
+
+        let source_path = entry.path();
+        let destination_path = destination.as_ref().join(entry.file_name());
+
+        if filetype.is_dir() {
+            create_dir(destination_path.as_path())?;
+            move_recursively(source_path.as_path(), destination_path.as_path())?;
+            remove_dir(source_path.as_path())?;
+        } else {
+            if filetype.is_file() {
+                copy(source_path.as_path(), destination_path.as_path())?;
+            } else if filetype.is_symlink() {
+                let target = read_link(source_path.as_path())?;
+                symlink(target, destination_path.as_path())?;
+            } else if filetype.is_char_device() || filetype.is_block_device() {
+                let source_stat = stat(source_path.as_path())?;
+                mknod(
+                    destination_path.as_path(),
+                    SFlag::from_bits_truncate(source_stat.st_mode),
+                    Mode::from_bits_truncate(source_stat.st_mode),
+                    source_stat.st_rdev,
+                )?;
+            }
+            remove_file(source_path)?;
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
When running in the initramfs move `/` from the special rootfs instance of tmpfs to a regular tmpfs. This is needed to allow pivot_root on `/` as the kernel does not allow unmount or pivot_root on the special rootfs instance.