### PR TITLE
Avoid allocating in `pre_exec` closure

### DIFF
--- a/feos/services/vm-service/src/vmm/ch_adapter.rs
+++ b/feos/services/vm-service/src/vmm/ch_adapter.rs
@@ -22,7 +22,6 @@ use hyperlocal::{UnixClientExt, UnixConnector, Uri as HyperlocalUri};
 use log::{error, info, warn};
 use nix::sys::signal::{kill, Signal};
 use nix::unistd::{self, Pid};
-use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::process::Command as TokioCommand;
@@ -269,7 +268,10 @@ impl Hypervisor for CloudHypervisorAdapter {
             TokioCommand::new(&self.ch_binary_path)
                 .arg("--api-socket")
                 .arg(&api_socket_path)
-                .pre_exec(|| unistd::setsid().map(|_pid| ()).map_err(io::Error::other))
+                .pre_exec(|| {
+                    unistd::setsid()?;
+                    Ok(())
+                })
                 .spawn()
         }
         .map_err(|e| VmmError::ProcessSpawnFailed(e.to_string()))?;


### PR DESCRIPTION
`Error::other` allocates memory (see https://github.com/rust-lang/rust/pull/148971). This is bad in multi-threaded programs, which FeOS AFAIK is. If the fork occurs while the allocator lock is held by another thread, deadlocks can occur, since there's no one left in the new process to unlock the mutex. I do not believe this is UB, and modern libc offer protections against this issue, but this isn't POSIX-compliant and should preferably be avoided.

`nix` provides a non-allocating `impl From<Errno> for std::io::Error`, which can be used instead. This also ensures that the correct error code is forwarded to the parent process, instead of the default `-EINVAL`.